### PR TITLE
chore(release): v0.3.0 — AI Setup Lanes v2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "gdlc-wizard",
       "source": ".",
       "description": "GDLC enforcement for AI agents — persona-driven playtest cycles, triangulated findings, ratchet-only-tightens. Sibling to sdlc-wizard, for games instead of code.",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "author": {
         "name": "Stefan Ayala"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gdlc-wizard",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "GDLC enforcement for AI agents — persona-driven playtest cycles, triangulated findings, ratchet-only-tightens. Sibling to claude-sdlc-wizard.",
   "author": {
     "name": "Stefan Ayala",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ This file tracks the **distribution wizard** (CLI, plugin, hooks, install script
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] — 2026-06-11
+
+**AI Setup Lanes v2 port from sdlc-wizard.** Adds the multi-lane setup flow (Quick, Standard, Deep) that adapts wizard installation depth to project complexity and user preference.
+
+### Added
+- **`AI_SETUP_LANES.md`** — complete v2 setup lanes document ported from `claude-sdlc-wizard`, adapted for GDLC context. Provides three installation paths (Quick lane for small projects, Standard lane for typical game repos, Deep lane for complex multi-module projects) with per-lane step registries and completion gates.
+
+---
+
 ## [0.2.2] — 2026-04-26
 
 **Issue-fix release.** Bundles the four playbook gaps surfaced by the codeguesser case study (issues #1, #3, #4) and the dogfooding finding from the codeguesser dual-install (issue #5).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap — GDLC Distribution
 
-> **Status (2026-04-26):** Phase 1 ✅ **SHIPPED + PUBLISHED**. `BaseInfinity/claude-gdlc-wizard` v0.2.2 live on npm. **Framework GRADUATED 2026-04-26** — playbook bumped to v0.4 with rule #35 (LLM-architecture vocabulary scrub for AI-character voices), the first earned rule from case study #2 (PDLC) absent from case study #1's ratchet. Graduation gate (per xdlc § "Case study first, framework second") fully met: adoption without modification ✅, earned rule absent from case #1 ✅. **Phases 2 (`codex-gdlc-wizard`) and 3 (Homebrew/gh CLI) are now UNBLOCKED.** See `PLAYBOOK_CHANGELOG.md` v0.5.0 for full graduation details.
+> **Status (2026-06-11):** Phase 1 ✅ **SHIPPED + PUBLISHED**. `BaseInfinity/claude-gdlc-wizard` v0.3.0 live on npm. **Framework GRADUATED 2026-04-26** — playbook bumped to v0.4 with rule #35 (LLM-architecture vocabulary scrub for AI-character voices), the first earned rule from case study #2 (PDLC) absent from case study #1's ratchet. Graduation gate (per xdlc § "Case study first, framework second") fully met: adoption without modification ✅, earned rule absent from case #1 ✅. **Phases 2 (`codex-gdlc-wizard`) and 3 (Homebrew/gh CLI) are now UNBLOCKED.** See `PLAYBOOK_CHANGELOG.md` v0.5.0 for full graduation details.
 
 ## North star
 
@@ -8,7 +8,7 @@ Mirror SDLC's distribution ecosystem:
 
 | Distribution repo | Host | Status | Phase |
 |---|---|---|---|
-| `BaseInfinity/claude-gdlc-wizard` | Claude Code | ✅ shipped — v0.2.2 on npm | Phase 1 |
+| `BaseInfinity/claude-gdlc-wizard` | Claude Code | ✅ shipped — v0.3.0 on npm | Phase 1 |
 | `BaseInfinity/codex-gdlc-wizard` | OpenAI Codex CLI | ⏸ pending | Phase 2 |
 | `BaseInfinity/gh-gdlc-wizard` | gh CLI extension | ⏸ pending | Phase 3 |
 | `BaseInfinity/homebrew-gdlc-wizard` | Homebrew tap | ⏸ pending | Phase 3 |
@@ -46,6 +46,7 @@ Source memory: `~/.claude/projects/-Users-stefanayala-codeguesser/memory/project
 | v0.2.0 | 2026-04-25 | **Path A consolidation** — framework playbook (`GDLC.md`) merged into wizard repo; `BaseInfinity/gdlc` deprecated |
 | v0.2.1 | 2026-04-25 | **Skill behavioral migration** — skills read project-local `CLAUDE_CODE_GDLC_WIZARD.md`, use `npx claude-gdlc-wizard check` for drift, WebFetch upstream playbook. No sibling clone required. |
 | v0.2.2 | 2026-04-26 | Issue-fix release (#1, #3, #4, #5, #7) + Codex round-1 hardening + Trusted Publishing workflow |
+| v0.3.0 | 2026-06-11 | AI Setup Lanes v2 port from sdlc-wizard — multi-lane setup flow (Quick/Standard/Deep) |
 
 **Distribution surfaces verified:**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-gdlc-wizard",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "GDLC enforcement for Claude Code \u2014 persona-driven playtest cycles, triangulated findings, ratchet-only-tightens. Sibling to claude-sdlc-wizard, for games instead of code.",
   "bin": {
     "gdlc-wizard": "cli/bin/gdlc-wizard.js"


### PR DESCRIPTION
## Summary
- Bump version 0.2.2 → 0.3.0 across all version sites (package.json, plugin.json, marketplace.json)
- Add CHANGELOG.md [0.3.0] entry documenting the AI Setup Lanes v2 port from sdlc-wizard
- Update ROADMAP.md status line, distribution table, and versions-shipped table

## Context
The `AI_SETUP_LANES.md` update merged to main. This PR completes the release by bumping version parity across all manifests and adding proper changelog/roadmap entries.

## Post-merge
Tag with `v0.3.0` after merge — the `npm-publish.yml` workflow (Trusted Publishing via OIDC) auto-publishes on `v*` tag push.